### PR TITLE
Deps: Bumped workflow actions to their latest versions

### DIFF
--- a/open-source/docker-action.md
+++ b/open-source/docker-action.md
@@ -29,13 +29,13 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       # Login against a Docker registry except on PR
       # https://github.com/docker/login-action
       - name: Log into registry ${{ env.REGISTRY }}
         if: github.event_name != 'pull_request'
-        uses: docker/login-action@28218f9b04b4f3f62068d7b6ce6ca5b26e35336c
+        uses: docker/login-action@v2
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -45,7 +45,7 @@ jobs:
       # https://github.com/docker/metadata-action
       - name: Extract Docker metadata
         id: meta
-        uses: docker/metadata-action@98669ae865ea3cffbcbaa878cf57c20bbf1c6c38
+        uses: docker/metadata-action@v4
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           tags: |
@@ -55,7 +55,7 @@ jobs:
       # Build and push Docker image with Buildx (don't push on PR)
       # https://github.com/docker/build-push-action
       - name: Build and push application Docker image
-        uses: docker/build-push-action@ad44023a93711e3deb337508980b4b5e9bcdc5dc
+        uses: docker/build-push-action@v4
         with:
           context: .
           push: ${{ github.event_name != 'pull_request' }}

--- a/open-source/greeting-action.md
+++ b/open-source/greeting-action.md
@@ -9,7 +9,7 @@ jobs:
   welcome:
       runs-on: ubuntu-latest
       steps:
-        - uses: actions/checkout@v1
+        - uses: actions/checkout@v3
         - uses: EddieHubCommunity/gh-action-community/src/welcome@main
           with:
             github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/open-source/stale-action.md
+++ b/open-source/stale-action.md
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/stale@v1
+    - uses: actions/stale@v8
       with:
         repo-token: ${{ secrets.GITHUB_TOKEN }}
         stale-issue-message: 'Stale issue message'


### PR DESCRIPTION
# Changes Proposed
## Bumped Deps:
- **actions/checkout** to _**v3**_
- **docker/login-action** to _**v2**_
- **docker/metadata-action** to _**v4**_
- **docker/build-push-action** to _**v4**_

#### @kaiwalyakoparkar Please review this PR. I have updated all the outdated github actions in the yml code in the open-source directory.